### PR TITLE
Added switch for full width row

### DIFF
--- a/src/Atoms/Row/row.js
+++ b/src/Atoms/Row/row.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 const Row = styled.div`
   display: flex;
-  width: 100%;
+  width: ${ ({ isInline }) => (isInline ? 'auto' : '100%') };
   align-items: ${ ({ alignItems }) => alignItems };
   flex-direction: ${ ({ flexDirection }) => flexDirection };
   flex-wrap: ${ ({ flexWrap }) => flexWrap };
@@ -18,7 +18,8 @@ Row.defaultProps = {
   flexDirection: 'row',
   flexWrap: 'wrap',
   justifyContent: 'flex-start',
-  padding: '0'
+  padding: '0',
+  isInline: false
 };
 
 Row.propTypes = {
@@ -27,7 +28,8 @@ Row.propTypes = {
   flexDirection: PropTypes.oneOf(['row', 'row-reverse', 'column', 'column-reverse']),
   flexWrap: PropTypes.oneOf(['wrap', 'no-wrap', 'wrap-reverse']),
   justifyContent: PropTypes.oneOf(['space-between', 'center', 'flex-start', 'flex-end']),
-  padding: PropTypes.string
+  padding: PropTypes.string,
+  isInline: PropTypes.bool
 };
 
 Row.displayName = 'Row';


### PR DESCRIPTION
# Description

- Added `isInline` Boolean to switch `width: 100%` and `width: auto`;

I could just pass width in and default to 100% but this is the only use-case I've come across with having to change the width on a flex element.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have updated the changelog
- [X] My branch has no conflicts with the branch I want to merge into
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
