### PR TITLE
Escape ampersands and chevrons from inputs

### DIFF
--- a/.storybook/changelog.json
+++ b/.storybook/changelog.json
@@ -1,4 +1,5 @@
 [
+{ "user": "Tim Stone", "version": "v0.11.23", "commit": "Adds an extra step to sanitising to allow '&', '<', '>' after DOMPurify has escaped them." },
 { "user": "Rich Comber", "version": "v0.11.22", "commit": "Making form prompt optional" },
 { "user": "Tim Stone", "version": "v0.11.21", "commit": "Switch is now customisable" },
 { "user": "Rich Comber", "version": "v0.11.20", "commit": "Udating release process" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salo/core-ui",
-  "version": "0.11.22",
+  "version": "0.11.23",
   "description": "Core Salo React UI library",
   "main": "./index.js",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "apollo-link-context": "~1.0.19",
     "apollo-upload-client": "~11.0.0",
     "apollo-utilities": "~1.3.2",
-    "dompurify": "~2.0.6",
+    "dompurify": "~2.0.7",
     "graphql": "~14.5.8",
     "graphql-tag": "~2.10.1",
     "hoist-non-react-statics": "~3.3.0",

--- a/src/helpers/form/index.js
+++ b/src/helpers/form/index.js
@@ -85,10 +85,26 @@ export const postcodeRegExp = /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(
 /**
  * SANITIZE HTML INPUT
  */
+const escapeHTML = str => str.replace(/(&amp;)|(&gt;)|(&lt;)/g,
+  match => {
+    // If it matches any of these tags they will be replaced
+    // by the non-escaped equivalent.
+    return {
+      '&amp;': '&',
+      '&lt;': '<',
+      '&gt;': '>'
+    }[match] || match;
+  });
 export const sanitize = (value) => {
-  return DomPurify.sanitize(value);
+  // DOMPurify does a cracking job at purifying for the DOM but in this case for display
+  // purposes we can de-escape '&' and chevrons as DOMPurify does the heavylifting for us
+  // of escaping bad content.
+  return escapeHTML(DomPurify.sanitize(value, {
+    USE_PROFILES: {
+      html: true
+    }
+  }));
 };
-
 
 /**
  * BUILD YUP SCHEMA
@@ -114,7 +130,9 @@ export const buildYup = ({ fields }) => {
     switch (type) {
       case 'string': {
         vRule = string();
-        vRule = minMaxInt({ min, max, vRule });
+        vRule = minMaxInt({
+          min, max, vRule
+        });
         if (regex) {
           vRule = vRule.matches(new RegExp(regex));
         }
@@ -122,13 +140,17 @@ export const buildYup = ({ fields }) => {
       }
       case 'password': {
         vRule = string();
-        vRule = minMaxInt({ min, max, vRule });
+        vRule = minMaxInt({
+          min, max, vRule
+        });
         vRule = vRule.matches(new RegExp(passwordRegex));
         break;
       }
       case 'number': {
         vRule = number();
-        vRule = minMaxInt({ min, max, vRule });
+        vRule = minMaxInt({
+          min, max, vRule
+        });
         break;
       }
       case 'boolean': {
@@ -141,7 +163,9 @@ export const buildYup = ({ fields }) => {
       case 'array':
       case 'arrayOfIds': {
         vRule = array();
-        vRule = minMaxInt({ min, max, vRule });
+        vRule = minMaxInt({
+          min, max, vRule
+        });
         break;
       }
       case 'date': {
@@ -177,7 +201,9 @@ export const buildYup = ({ fields }) => {
       }
       case 'email': {
         vRule = string().email();
-        vRule = minMaxInt({ min, max, vRule });
+        vRule = minMaxInt({
+          min, max, vRule
+        });
         break;
       }
       case 'tel': {
@@ -186,7 +212,9 @@ export const buildYup = ({ fields }) => {
       }
       case 'url': {
         vRule = string().url();
-        vRule = minMaxInt({ min, max, vRule });
+        vRule = minMaxInt({
+          min, max, vRule
+        });
         break;
       }
       case 'file': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4605,9 +4605,10 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-dompurify@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.6.tgz#0a4196c211ce00e848240e52b1d49261af12a3be"
+dompurify@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.7.tgz#f8266ad38fe1602fb5b3222f31eedbf5c16c4fd5"
+  integrity sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A==
 
 domutils@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
# Description

* Adds an extra step to sanitising to allow '&', '<', '>' after DOMPurify has escaped them.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have updated the changelog
- [X] My branch has no conflicts with the branch I want to merge into
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
