### PR TITLE
Allow arrays and non-arrays as select value for Typeaheads in forms

### DIFF
--- a/.storybook/changelog.json
+++ b/.storybook/changelog.json
@@ -1,4 +1,5 @@
 [
+{ "user": "Tim Stone", "version": "v1.3.8", "commit": "Allow arrays and non-arrays as select value for Typeaheads in forms" },
 { "user": "Rich Comber", "version": "v1.3.7", "commit": "Adding class to datepicker" },
 { "user": "Rich Comber", "version": "v1.3.6", "commit": "Updating package" },
 { "user": "Rich Comber", "version": "v1.3.5", "commit": "Fixing datepicker" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salo/core-ui",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Core Salo React UI library",
   "main": "./index.js",
   "sideEffects": false,

--- a/src/Organisms/DynamicForm/form.renderFields.js
+++ b/src/Organisms/DynamicForm/form.renderFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  get, isEmpty, forEach, map
+  get, isEmpty, forEach, map, isArray
 } from 'lodash';
 import styled from 'styled-components';
 
@@ -129,16 +129,19 @@ const RenderFields = (props) => {
             name={ name }
             onChange={ ({ value: val }) => {
               handleChange({
-                key: name, value: val
+                key: name,
+                value: val
               });
               if (typeof typeahead.callback === 'function') {
                 typeahead.callback({
-                  key: name, value: val
+                  key: name,
+                  value: val
                 });
               }
             } }
             onSelect={ (val) => handleBlur({
-              key: name, value: val.map((v) => v.id)
+              key: name,
+              value: isArray(val) ? val.map((v) => v.id) : val
             }) }
             required={ required }
             value={ values[name] }


### PR DESCRIPTION
# Description

Allow arrays and non-arrays as select value for Typeaheads in forms

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have updated the changelog
- [X] My branch has no conflicts with the branch I want to merge into
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
