### PR TITLE
Loosen auth peer dep and allow styled components 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,11 +121,11 @@
     "webpack": "~4.41.3"
   },
   "peerDependencies": {
-    "@salo/auth": "~0.0.2",
+    "@salo/auth": "^0.0.2",
     "@salo/icons": "^1.1.11",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "styled-components": "^4.2.0"
+    "styled-components": "^4.2.0 || ^5.0.0"
   },
   "dependencies": {
     "@apollo/react-hooks": "~3.1.3",


### PR DESCRIPTION
# Description

* Loosen @salo/auth peer dep to remove warning
* Allow styled components 5 as it has no breaking changes and been out for a while now
