### PR TITLE
Allow custom components as tab titles

### DIFF
--- a/src/Molecules/Tab/README.md
+++ b/src/Molecules/Tab/README.md
@@ -32,3 +32,16 @@ const panes = [
 
 <Tab panes={ panes } />
 ```
+
+Or with complex titles:
+
+```javascript
+const panes = [
+  { 
+    title: 'Tab 1',
+    children: <h1>Tab 1</h1>,
+    render: (
+      <p>This tab has JSX content</p>
+    ),
+  }
+];

--- a/src/Molecules/Tab/tab.js
+++ b/src/Molecules/Tab/tab.js
@@ -60,7 +60,7 @@ const Tab = (props) => {
               tabIndex={ index === focus ? 0 : -1 }
               type='button'
             >
-              { pane.title }
+              { pane.children || pane.title }
             </TabButton>
           );
         }) }
@@ -84,15 +84,18 @@ const Tab = (props) => {
   );
 };
 
-Tab.defaultProps = { className: '' };
+Tab.defaultProps = {
+  className: ''
+};
 
 Tab.propTypes = {
   className: PropTypes.string,
   panes: PropTypes.arrayOf(
     PropTypes.shape({
+      children: PropTypes.any,
       title: PropTypes.string,
       render: PropTypes.func.isRequired
-    }),
+    })
   ).isRequired
 };
 


### PR DESCRIPTION
# Description

* Allow custom children as tab titles

Usage:

```javascript
const panes = [{
    title: 'Title',
    children: <CustomComponent />,
    render: () => (
      <p>This tab has JSX content</p>
    )
  }
];
```

`children` may be too generic a name, `titleChildren`? `titleComponent`?

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have updated the changelog
- [X] I have considered the risk this change brings using the DREAD formula and updated documentation if necessary
- [X] My branch has no conflicts with the branch I want to merge into
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
